### PR TITLE
separate interfaces

### DIFF
--- a/semaphore.go
+++ b/semaphore.go
@@ -7,12 +7,17 @@ import (
 
 // Semaphore defines the base interface.
 type Semaphore interface {
-	HealthCheck
 	// Acquire tries to take an available place with the given timeout.
 	// If the timeout has occurred, then returns an appropriate error.
 	Acquire(time.Duration) error
 	// Release releases the previously occupied place.
 	Release()
+}
+
+// SemaphoreWithHealthCheck defines extended version of Semaphore with healthcheck information
+type SemaphoreWithHealthCheck interface {
+	Semaphore
+	HealthCheck
 }
 
 // HealthCheck defines some helpful methods related with capacity for monitoring.
@@ -25,6 +30,11 @@ type HealthCheck interface {
 
 // New constructs a new Semaphore with the given number of places.
 func New(size int) Semaphore {
+	return make(semaphore, size)
+}
+
+// New constructs a new Semaphore with the given number of places.
+func NewWithHealthCheck(size int) SemaphoreWithHealthCheck {
 	return make(semaphore, size)
 }
 

--- a/semaphore_test.go
+++ b/semaphore_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSemaphore_Concurrently(t *testing.T) {
 	size := int(math.Max(2.0, float64(runtime.GOMAXPROCS(0))))
-	sem := New(size)
+	sem := NewWithHealthCheck(size)
 	var counter int32
 
 	start := make(chan bool)


### PR DESCRIPTION
because for monitored semaphore decorator I don't need to show healthcheck methods to outside. And not everyone will need semaphore with healthcheck, so better to have basic version and extended version of the interface.

So, in my decorator now I can use:
```go
type semaphoreDecorator {
    sem SemaphoreWithHealthCheck
}

func NewSemaphoreDecorator(size int) Semaphore {
    return &semaphoreDecorator{
        sem: NewWithHealthcheck(size),
    }
}
```

Basic interface is showed outside and extended interface is used inside. Convenient.